### PR TITLE
Add new data repos to .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,11 @@ ioda/
 oops/
 ufo/
 
+# data repos
+ioda-data/
+ufo-data/
+fv3-jedi-data/
+
 # fv3-jedi and related repos
 fms/
 fv3/


### PR DESCRIPTION
## Description

This PR is a small cleanup detail that adds the new test data repos (ioda-data, ufo-data, fv3-jedi-data) to the .gitignore configuration file so that these directories don't show up with `git status` commands.

## Definition of Done

The new test data repos don't show up when running `git status`

### Issue(s) addressed

None

## Dependencies

None

## Impact

None
