### PR TITLE
use public forks for GFDL_atmos_cubed_sphere, FMS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,8 +58,8 @@ ecbuild_bundle( PROJECT ioda  GIT "https://github.com/jcsda/ioda.git"  BRANCH de
 ecbuild_bundle( PROJECT ufo   GIT "https://github.com/jcsda/ufo.git"   BRANCH develop UPDATE )
 
 # FMS and FV3 dynamical core
-ecbuild_bundle( PROJECT fms GIT "https://github.com/jcsda-internal/FMS.git" BRANCH release-stable UPDATE )
-ecbuild_bundle( PROJECT fv3 GIT "https://github.com/jcsda-internal/GFDL_atmos_cubed_sphere.git" BRANCH release-stable UPDATE )
+ecbuild_bundle( PROJECT fms GIT "https://github.com/jcsda/FMS.git" BRANCH release-stable UPDATE )
+ecbuild_bundle( PROJECT fv3 GIT "https://github.com/jcsda/GFDL_atmos_cubed_sphere.git" BRANCH release-stable UPDATE )
 
 # fv3-jedi and associated repositories
 ecbuild_bundle( PROJECT femps       GIT "https://github.com/jcsda/femps.git"                BRANCH develop UPDATE )


### PR DESCRIPTION
## Description

This just modifies the develop branch of the public fv3-bundle to use the public (JCSDA) versions of our forks of the `GFDL_atmos_cubed_sphere` and `FMS` repos.  The plan is to delete the internal versions as soon as tomorrow.

The most recent tagged release already has this change and the develop branch of JCSDA-internal/fv3-bundle already has this change.
